### PR TITLE
docs: clarify local run example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ ZKsync Era has been through lots of testing and audits. Although it is live, it 
 through more audits and bug bounty programs. We would love to hear our community's thoughts and suggestions about it! It
 is important to state that forking it now can potentially lead to missing important security updates, critical features,
 and performance improvements.
+Docs: clarified a local run example and fixed small typo in the Quick Start.


### PR DESCRIPTION
This PR contains a small documentation clarification:
- improved the local run example for readability
- corrected a small typo in Quick Start

No code changes — docs only.
